### PR TITLE
Fix: NullPointer exception while alert engine startup in v1.0.8

### DIFF
--- a/hypertrace-alert-engine/src/main/resources/configs/common/application.conf
+++ b/hypertrace-alert-engine/src/main/resources/configs/common/application.conf
@@ -16,7 +16,7 @@ notificationChannelsSource = {
   type = "fs"
   fs = {
     path = "build/resources/main/configs/notification-channels.json"
-    path = ${?ALERT_RULES_PATH}
+    path = ${?NOTIFICATION_CHANNELS_PATH}
   }
   dataStore = {
     dataStoreType = mongo


### PR DESCRIPTION
While refactoring missed entering the notification channel path at one place which caused this error. It seems while testing, previous image was used and thus the test passed. 

Corresponding Issue: https://github.com/hypertrace/hypertrace-alert-engine/issues/44