### PR TITLE
fix: update kafka-clients in order to fix vulnerability

### DIFF
--- a/metric-anomaly-data-model/build.gradle.kts
+++ b/metric-anomaly-data-model/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     api("javax.annotation:javax.annotation-api:1.3.2")
     api("org.apache.avro:avro:1.10.2")
     implementation("com.typesafe:config:1.4.1")
-    implementation("org.apache.kafka:kafka-clients:2.6.0")
+    implementation("org.apache.kafka:kafka-clients:2.8.1")
     implementation("org.hypertrace.core.documentstore:document-store:0.5.7")
     implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-serdes:0.1.22")
     implementation("io.confluent:kafka-streams-avro-serde:6.0.1")

--- a/metric-anomaly-detector/build.gradle.kts
+++ b/metric-anomaly-detector/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     implementation("com.typesafe:config:1.4.1")
     implementation("org.hypertrace.gateway.service:gateway-service-api:0.1.59")
     implementation("org.hypertrace.gateway.service:gateway-service-baseline-lib:0.1.167")
-    implementation("org.apache.kafka:kafka-clients:2.6.0")
+    implementation("org.apache.kafka:kafka-clients:2.8.1")
     implementation("com.google.protobuf:protobuf-java-util:4.0.0-rc-2")
     implementation("com.google.guava:guava:30.1.1-jre")
     implementation("org.hypertrace.config.service:alerting-config-service-api:0.1.12")

--- a/metric-anomaly-task-manager/build.gradle.kts
+++ b/metric-anomaly-task-manager/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(project(":metric-anomaly-data-model"))
     implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.23")
     implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
-    implementation("org.apache.kafka:kafka-clients:2.6.0")
+    implementation("org.apache.kafka:kafka-clients:2.8.1")
     implementation("org.hypertrace.core.documentstore:document-store:0.5.7")
     implementation("org.hypertrace.config.service:config-service-api:0.1.12")
     implementation("org.hypertrace.config.service:alerting-config-service-api:0.1.12")

--- a/notification-service/build.gradle.kts
+++ b/notification-service/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.4")
     implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.23")
     implementation("com.typesafe:config:1.4.1")
-    implementation("org.apache.kafka:kafka-clients:2.6.0")
+    implementation("org.apache.kafka:kafka-clients:2.8.1")
     implementation("com.google.protobuf:protobuf-java-util:4.0.0-rc-2")
     implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-serdes:0.1.22")
     implementation("io.confluent:kafka-streams-avro-serde:6.0.1")


### PR DESCRIPTION
## Description
Fix a Kafka clients vulnerability in v2.6.0. 

```
CVE-2021-38153  suppress

Some components in Apache Kafka use `Arrays.equals` to validate a password or key, which is vulnerable to timing attacks that make brute force attacks for such credentials more likely to be successful. Users should upgrade to 2.8.1 or higher, or 3.0.0 or higher where this vulnerability has been fixed. The affected versions include Apache Kafka 2.0.0, 2.0.1, 2.1.0, 2.1.1, 2.2.0, 2.2.1, 2.2.2, 2.3.0, 2.3.1, 2.4.0, 2.4.1, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, and 2.8.0.
CWE-203 Information Exposure Through Discrepancy

CVSSv2:
Base Score: MEDIUM (4.3)
Vector: /AV:N/AC:M/Au:N/C:P/I:N/A:N
CVSSv3:
Base Score: MEDIUM (5.9)
Vector: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N

References:
CONFIRM - N/A
MLIST - [kafka-dev] 20211007 Re: CVE Back Port?
MLIST - [kafka-dev] 20211012 [VOTE] 2.6.3 RC0
MLIST - [kafka-dev] 20211012 [VOTE] 2.7.2 RC0
MLIST - [kafka-dev] 20211026 Re: [kafka-clients] [VOTE] 2.7.2 RC0
MLIST - [kafka-users] 20211012 [VOTE] 2.6.3 RC0
MLIST - [kafka-users] 20211012 [VOTE] 2.7.2 RC0
MLIST - [kafka-users] 20211026 Re: [kafka-clients] [VOTE] 2.7.2 RC0
Vulnerable Software & Versions:

cpe:2.3:a:apache:kafka:*:*:*:*:*:*:*:* versions from (including) 2.0.0; versions up to (excluding) 2.8.
```