### PR TITLE
chore: update codecov gha to v2

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -33,7 +33,7 @@ jobs:
           args: jacocoTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           name: unit test reports
           fail_ci_if_error: true
@@ -45,7 +45,7 @@ jobs:
           args: jacocoIntegrationTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           name: integration test reports
           fail_ci_if_error: true

--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,10 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: No replacement available
-        expires: 2022-01-31T00:00:00.000Z
+        expires: 2022-05-31T00:00:00.000Z
+  SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744:
+    - '*':
+        reason: No replacement available
+        expires: 2022-05-31T00:00:00.000Z
 patch: {}
 

--- a/hypertrace-alert-engine/build.gradle.kts
+++ b/hypertrace-alert-engine/build.gradle.kts
@@ -25,14 +25,14 @@ dependencies {
     implementation(project(":metric-anomaly-detector"))
     implementation(project(":notification-service"))
 
-    implementation("org.hypertrace.core.documentstore:document-store:0.5.7")
+    implementation("org.hypertrace.core.documentstore:document-store:0.6.7")
 
     // Logging
     implementation("org.slf4j:slf4j-api:1.7.30")
-    runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0")
+    runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
     // framework + libs
-    implementation("com.google.protobuf:protobuf-java-util:3.17.3")
+    implementation("com.google.protobuf:protobuf-java-util:3.19.4")
     implementation("org.quartz-scheduler:quartz:2.3.2")
 
     // integration test
@@ -53,7 +53,7 @@ dependencies {
     integrationTestImplementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-serdes:0.1.13")
     integrationTestImplementation("org.hypertrace.core.query.service:query-service-client:0.6.2")
     integrationTestImplementation("org.hypertrace.core.attribute.service:attribute-service-client:0.12.0")
-    integrationTestImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
+    integrationTestImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
 }
 
 tasks.run<JavaExec> {

--- a/metric-anomaly-data-model/build.gradle.kts
+++ b/metric-anomaly-data-model/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 dependencies {
   api("org.apache.avro:avro:1.10.2")
-  api("io.grpc:grpc-protobuf:1.42.0")
-  api("io.grpc:grpc-stub:1.42.0")
+  api("io.grpc:grpc-protobuf:1.42.2")
+  api("io.grpc:grpc-stub:1.42.2")
   api("javax.annotation:javax.annotation-api:1.3.2")
   api("org.apache.avro:avro:1.10.2")
   implementation("com.typesafe:config:1.4.1")
   implementation("org.apache.kafka:kafka-clients:2.6.0")
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.7")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.7")
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-serdes:0.1.23")
   implementation("io.confluent:kafka-streams-avro-serde:6.0.1")
   constraints {

--- a/metric-anomaly-detector/build.gradle.kts
+++ b/metric-anomaly-detector/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation("org.hypertrace.gateway.service:gateway-service-api:0.1.59")
   implementation("org.hypertrace.gateway.service:gateway-service-baseline-lib:0.1.167")
   implementation("org.apache.kafka:kafka-clients:2.6.0")
-  implementation("com.google.protobuf:protobuf-java-util:3.17.3")
+  implementation("com.google.protobuf:protobuf-java-util:3.19.4")
   implementation("com.google.guava:guava:30.1.1-jre")
   implementation("org.hypertrace.config.service:alerting-config-service-api:0.1.12")
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-serdes:0.1.23")
@@ -47,9 +47,9 @@ dependencies {
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
-  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0")
+  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
-  runtimeOnly("io.grpc:grpc-netty:1.42.0")
+  runtimeOnly("io.grpc:grpc-netty:1.42.2")
   constraints {
     runtimeOnly("io.netty:netty-codec-http2:4.1.71.Final")
     runtimeOnly("io.netty:netty-handler-proxy:4.1.71.Final")

--- a/metric-anomaly-task-manager/build.gradle.kts
+++ b/metric-anomaly-task-manager/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.32")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.32")
   implementation("org.apache.kafka:kafka-clients:2.6.0")
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.7")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.7")
   implementation("org.hypertrace.config.service:config-service-api:0.1.12")
   implementation("org.hypertrace.config.service:alerting-config-service-api:0.1.12")
   implementation("org.hypertrace.config.service:notification-rule-config-service-api:0.1.12")
@@ -35,16 +35,16 @@ dependencies {
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
-  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0")
+  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
-  runtimeOnly("io.grpc:grpc-netty:1.42.0")
+  runtimeOnly("io.grpc:grpc-netty:1.42.2")
   constraints {
     runtimeOnly("io.netty:netty-codec-http2:4.1.71.Final")
     runtimeOnly("io.netty:netty-handler-proxy:4.1.71.Final")
   }
 
   // framework + libs
-  implementation("com.google.protobuf:protobuf-java-util:3.17.3")
+  implementation("com.google.protobuf:protobuf-java-util:3.19.4")
   implementation("org.quartz-scheduler:quartz:2.3.2")
 
   // testing

--- a/notification-service/build.gradle.kts
+++ b/notification-service/build.gradle.kts
@@ -19,7 +19,7 @@ tasks.test {
 dependencies {
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.32")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.32")
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.7")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.7")
   implementation("org.hypertrace.config.service:notification-channel-config-service-api:0.1.12")
   implementation("org.hypertrace.config.service:config-proto-converter:0.1.12")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.2")
@@ -32,7 +32,7 @@ dependencies {
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.32")
   implementation("com.typesafe:config:1.4.1")
   implementation("org.apache.kafka:kafka-clients:2.6.0")
-  implementation("com.google.protobuf:protobuf-java-util:3.17.3")
+  implementation("com.google.protobuf:protobuf-java-util:3.19.4")
   implementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-serdes:0.1.23")
   implementation("io.confluent:kafka-streams-avro-serde:6.0.1")
   constraints {
@@ -46,9 +46,9 @@ dependencies {
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
-  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0")
+  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
-  runtimeOnly("io.grpc:grpc-netty:1.42.0")
+  runtimeOnly("io.grpc:grpc-netty:1.42.2")
   constraints {
     runtimeOnly("io.netty:netty-codec-http2:4.1.71.Final")
     runtimeOnly("io.netty:netty-handler-proxy:4.1.71.Final")
@@ -58,7 +58,7 @@ dependencies {
   testImplementation("org.mockito:mockito-core:3.9.0")
   testImplementation("org.mockito:mockito-inline:3.9.0")
   testImplementation("org.junit-pioneer:junit-pioneer:1.3.8")
-  testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
+  testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
 }
 
 tasks.test {

--- a/notification-transport/build.gradle.kts
+++ b/notification-transport/build.gradle.kts
@@ -7,17 +7,17 @@ import com.google.protobuf.gradle.protoc
 
 plugins {
   `java-library`
-  id("com.google.protobuf") version "0.8.12"
+  id("com.google.protobuf") version "0.8.18"
   id("io.freefair.lombok")
 }
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.17.3"
+    artifact = "com.google.protobuf:protoc:3.19.4"
   }
   plugins {
     id("grpc") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.42.0"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.42.2"
     }
   }
   generateProtoTasks {
@@ -31,17 +31,20 @@ protobuf {
 
 dependencies {
   implementation("com.typesafe:config:1.4.1")
-  implementation("com.sendgrid:sendgrid-java:4.8.1")
+  implementation("com.sendgrid:sendgrid-java:4.8.2")
   constraints {
     implementation("commons-codec:commons-codec:1.13") {
       because("https://snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518")
     }
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698")
+    }
   }
-  implementation("com.squareup.okhttp3:okhttp:4.9.1")
+  implementation("com.squareup.okhttp3:okhttp:4.9.3")
   implementation("com.google.guava:guava:30.1-jre")
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
-  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0")
+  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
 }


### PR DESCRIPTION
## Description
Codecov bash uploader is being deprecated and is currently in the brownout phase. We need to upgrade to the v2 gh action in all repos.

More info: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/